### PR TITLE
Fix build for 'alloc' feature

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -2,6 +2,9 @@
 use serde::ser;
 use serde::Serialize;
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 use crate::{Error, Result, MAX_CONTAINER_DEPTH};
 
 use self::{flavors::Flavor, serializer::Serializer};


### PR DESCRIPTION
This makes the build work when `--no-default-features --features=alloc`. Without this patch `Vec` is not in scope.